### PR TITLE
improved usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ You can see all the methods in the documentation on GitHub
 ## Usage
 A quick example of creating a client:
 ```python
+async with Server("wg.example.com", 51821, "SuPerSecret_pass") as server:
+    await server.create_client("client_name")
+```
+Or a slightly more complicated way:
+```python
 async with aiohttp.ClientSession() as session:
     server = Server("wg.example.com", 51821, "SuPerSecret_pass", session)
     await server.login()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wg-easy-api-wrapper
-version = 1.0.2
+version = 1.0.3
 author = MrShandy
 author_email = mrshandy@shandy-dev.ru
 description = Wrapper for wg-easy API

--- a/wg_easy_api_wrapper/__init__.py
+++ b/wg_easy_api_wrapper/__init__.py
@@ -1,2 +1,3 @@
 from .client import Client
 from .server import Server
+from .errors import *

--- a/wg_easy_api_wrapper/__init__.py
+++ b/wg_easy_api_wrapper/__init__.py
@@ -1,3 +1,3 @@
 from .client import Client
-from .server import Server
 from .errors import *
+from .server import Server

--- a/wg_easy_api_wrapper/client.py
+++ b/wg_easy_api_wrapper/client.py
@@ -23,7 +23,7 @@ class Client:
                  transfer_tx: int,
                  updated_at: str,
                  session: aiohttp.ClientSession,
-                 server: 'Server',):
+                 server: 'Server', ):
         self._address = address
         self._created_at = datetime.strptime(created_at, time_format)
         self._enabled = bool(enabled)

--- a/wg_easy_api_wrapper/errors.py
+++ b/wg_easy_api_wrapper/errors.py
@@ -1,0 +1,2 @@
+class AlreadyLoggedInError(Exception):
+    pass

--- a/wg_easy_api_wrapper/server.py
+++ b/wg_easy_api_wrapper/server.py
@@ -19,13 +19,16 @@ class Server:
     def url_builder(self, path: str) -> str:
         return f"http://{self.host}:{self.port}{path}"
 
-    def __enter__(self):
-        if self._session is None:
-            self._session = aiohttp.ClientSession()
+    async def __aenter__(self):
+        await self.login()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self._session.close()
+    async def __aexit__(self, exc_type, exc, exc_tb):
+        if await self.is_logged_in():
+            await self.logout()
+        await self._session.close()
+        if exc:
+            raise exc
 
     async def login(self):
         if await self.is_logged_in():

--- a/wg_easy_api_wrapper/server.py
+++ b/wg_easy_api_wrapper/server.py
@@ -5,11 +5,11 @@ from .errors import AlreadyLoggedInError
 
 
 class Server:
-    def __init__(self, host: str, port: int, password: str):
+    def __init__(self, host: str, port: int, password: str, session: aiohttp.ClientSession = None):
         self.host = host
         self.port = port
         self._password = password
-        self._session = aiohttp.ClientSession()
+        self._session = aiohttp.ClientSession() if session is None else session
 
     async def is_logged_in(self):
         session = await self.get_session()

--- a/wg_easy_api_wrapper/server.py
+++ b/wg_easy_api_wrapper/server.py
@@ -5,7 +5,7 @@ from .client import Client
 
 
 class Server:
-    def __init__(self, host: str, port: int, password: str, session: aiohttp.ClientSession = None):
+    def __init__(self, host: str, port: int, password: str):
         self.host = host
         self.port = port
         self._password = password

--- a/wg_easy_api_wrapper/server.py
+++ b/wg_easy_api_wrapper/server.py
@@ -1,7 +1,7 @@
 import aiohttp
 
-from .errors import AlreadyLoggedInError
 from .client import Client
+from .errors import AlreadyLoggedInError
 
 
 class Server:
@@ -61,7 +61,3 @@ class Server:
             self.url_builder("/api/wireguard/client"),
             json={"name": name},
         )
-
-
-
-


### PR DESCRIPTION
Added use in `async with` construction, which should be easier
before:
```py
async with aiohttp.ClientSession() as session:
    server = Server("wg.example.com", 51821, "SuPerSecret_pass", session)
    await server.login()
    await server.create_client("client_name")
```
after:
```py
async with Server("wg.example.com", 51821, "SuPerSecret_pass") as server:
    await server.create_client("client_name")
```